### PR TITLE
Track withUser component mount status

### DIFF
--- a/src/withUser.js
+++ b/src/withUser.js
@@ -8,15 +8,17 @@ const withUser = Component => class Wrapper extends React.Component {
     this.user = this.store.getState().getIn(['accounts', 'user']);
   }
   componentDidMount() {
+    this.mounted = true;
     this.unsubscribe = this.store.subscribe(() => {
       const user = this.store.getState().getIn(['accounts', 'user']);
-      if (!user.equals(this.user)) {
+      if (this.mounted && !user.equals(this.user)) {
         this.user = user;
         this.forceUpdate();
       }
     });
   }
   componentWillUnmount() {
+    this.mounted = false;
     this.unsubscribe();
   }
   render() {


### PR DESCRIPTION
This will avoid throwing a no op when forceUpdate is called on an unmounted components. As a future issue I need to reexamine the update code since rather than calling forceUpdate the user can be just tracked in the component state.