### PR TITLE
Fix resume session

### DIFF
--- a/packages/react/src/accountRoutes.js
+++ b/packages/react/src/accountRoutes.js
@@ -8,7 +8,6 @@ const DefaultContainer = ({ children }) => children;
 
 const onEnter = accounts => async (nextState, replace, callback) => {
   try {
-    await accounts.resumeSession();
     if (accounts.user()) {
       replace(accounts.options().homePath);
     }

--- a/packages/react/src/authenticate.js
+++ b/packages/react/src/authenticate.js
@@ -36,18 +36,6 @@ class Authenticate extends React.Component {
         });
       }
     });
-    if (this.mounted) {
-      try {
-        this.setState({
-          showDialog: false,
-        });
-        await accounts.resumeSession();
-      } catch (err) {
-        this.setState({
-          showDialog: true,
-        });
-      }
-    }
   }
   componentWillUnmount() {
     this.mounted = false;

--- a/packages/react/src/withCurrentUser.js
+++ b/packages/react/src/withCurrentUser.js
@@ -10,7 +10,7 @@ class WithCurrentUser extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
-      user: null,
+      user: props.accounts.user() || null,
     };
   }
   async componentDidMount() {
@@ -33,9 +33,6 @@ class WithCurrentUser extends React.Component {
         });
       }
     });
-    try {
-      await accounts.resumeSession();
-    } catch (err) {} //eslint-disable-line
   }
   componentWillUnmount() {
     this.mounted = false;


### PR DESCRIPTION
Currently resumeSession is called before config is finished. This make the tokens be reset before the user is loaded. The session is lost each time you reload the page.

In order to make it work you will have to init your client like that:
```javascript
(async () => {
  await AccountsClient.config({
    server: 'http://localhost:3010',
    tokenStoragePrefix: 'express-rest',
    history: browserHistory,
    title: 'express-rest',
    loginPath: '/login',
    signUpPath: '/signup',
    homePath: '/',
    reduxLogger: createLogger(),
    passwordSignupFields: 'USERNAME_AND_EMAIL',
  }, new RestClient({
    apiHost: 'http://localhost:3010',
    rootPath: '/accounts',
  }));
  await AccountsClient.resumeSession();
})();
```